### PR TITLE
move docker image check to config

### DIFF
--- a/wpdev_api/src/main.rs
+++ b/wpdev_api/src/main.rs
@@ -3,8 +3,6 @@ extern crate rocket;
 use rocket::http::Method;
 use rocket_cors::{AllowedOrigins, Cors, CorsOptions};
 
-use wpdev_core::config;
-
 mod routes;
 
 fn cors() -> Cors {
@@ -26,12 +24,6 @@ fn cors() -> Cors {
 
 #[launch]
 fn rocket() -> _ {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
-    if let Err(err) = rt.block_on(config::pull_docker_images_from_config()) {
-        eprintln!("Error pulling Docker images: {:?}", err);
-        std::process::exit(1);
-    }
     rocket::build()
         .attach(cors())
         .mount("/api", routes::routes())

--- a/wpdev_cli/src/main.rs
+++ b/wpdev_cli/src/main.rs
@@ -72,7 +72,6 @@ async fn main() -> Result<()> {
         .context("Failed to read or create config")?;
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(config.log_level))
         .init();
-    config::pull_docker_images_from_config().await?;
     let cli = Cli::parse();
     match cli.command {
         Commands::List(args) => {

--- a/wpdev_core/src/config.rs
+++ b/wpdev_core/src/config.rs
@@ -36,6 +36,9 @@ pub async fn read_or_create_config() -> Result<crate::AppConfig> {
                 info!("Custom root not found in config, setting to default value");
                 config.custom_root = Some(default_config_dir);
             }
+            //TODO: Add a more performant method to check if images have been pulled.
+            // Currently the first time this runs it will block for a while until all images have
+            // been pulled.
             pull_docker_images_from_config(&config).await?;
             info!("Config file read successfully");
             Ok(config)


### PR DESCRIPTION
- check for docker images during config, this is a slow first run but once the images exist subsequent pulls are faster. We should consider a better way to do this.